### PR TITLE
chore: update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,113 @@
-/.phpunit.cache
-/build
-/vendor
+#####################################
+# OS依存ファイル
+#####################################
+.DS_Store
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+#####################################
+# 一時ファイル・ログ・バックアップ
+#####################################
+*.log
+*.tmp
+*.swp
+*.swo
+*.bak
+*.orig
+
+#####################################
+# 環境変数・機密情報
+#####################################
+.env
+.env.*
+*.key
+*.pem
+
+#####################################
+# ビルド成果物・キャッシュ
+#####################################
+dist/
+build/
+out/
+tmp/
+cache/
+*.pyc
+__pycache__/
+
+#####################################
+# IDE / エディタ設定
+#####################################
+# VSCode
+.vscode/
+.history/
+
+# JetBrains系（PhpStormなど）
+.idea/
+
+#####################################
+# Node.js関連
+#####################################
+node_modules/
+npm-debug.log
+yarn-error.log
+*.lock
+
+#####################################
+# PHP関連設定
+#####################################
+
+# Composerの依存関係
+vendor/
+composer.phar
+
+# PHPUnitのキャッシュとレポート
 .phpunit.result.cache
+phpunit.xml.dist
+
+# PHP-CS-Fixerのキャッシュ
+.php-cs-fixer.cache
+
+# PHPStanやPsalmなど静的解析ツールのキャッシュ
+.phpstan/
+psalm.xml.dist
+
+# SymfonyやLaravelなどのキャッシュ・ログ・セッション
+storage/
+bootstrap/cache/
+var/
+*.cache
+
+# Laravel特有
+.env.backup
+.env.local
+.env.production
+.env.testing
+homestead.yaml
+Homestead.yaml
+Homestead.json
+.idea/
+
+# WordPress（テーマ・プラグイン開発時）
+wp-content/uploads/
+wp-content/cache/
+wp-content/upgrade/
+wp-content/debug.log
+
+#####################################
+# カバレッジ関連
+#####################################
+coverage/
+*.lcov
+
+#####################################
+# その他
+#####################################
+*.iml
+*.class
+*.o
+*.out
+*.so
+*.dll
+*.exe
+*.pid

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,8 @@ __pycache__/
 node_modules/
 npm-debug.log
 yarn-error.log
+yarn-debug.log*
+pnpm-debug.log*
 
 #####################################
 # PHP関連設定
@@ -65,6 +67,7 @@ composer.phar
 # PHPUnitのキャッシュとレポート
 .phpunit.cache
 .phpunit.result.cache
+phpunit.result.cache
 phpunit.xml
 
 # PHP-CS-Fixerのキャッシュ
@@ -77,7 +80,8 @@ psalm.xml
 # SymfonyやLaravelなどのキャッシュ・ログ・セッション
 storage/
 bootstrap/cache/
-var/
+var/cache/
+var/log/
 *.cache
 
 # Laravel特有
@@ -88,7 +92,6 @@ var/
 homestead.yaml
 Homestead.yaml
 Homestead.json
-.idea/
 
 # WordPress（テーマ・プラグイン開発時）
 wp-content/uploads/

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ Desktop.ini
 #####################################
 .env
 .env.*
+!.env.example
+!.env.*.example
 *.key
 *.pem
 
@@ -51,7 +53,6 @@ __pycache__/
 node_modules/
 npm-debug.log
 yarn-error.log
-*.lock
 
 #####################################
 # PHP関連設定
@@ -62,15 +63,16 @@ vendor/
 composer.phar
 
 # PHPUnitのキャッシュとレポート
+.phpunit.cache
 .phpunit.result.cache
-phpunit.xml.dist
+phpunit.xml
 
 # PHP-CS-Fixerのキャッシュ
 .php-cs-fixer.cache
 
 # PHPStanやPsalmなど静的解析ツールのキャッシュ
 .phpstan/
-psalm.xml.dist
+psalm.xml
 
 # SymfonyやLaravelなどのキャッシュ・ログ・セッション
 storage/


### PR DESCRIPTION
.gitignore に PHP だけではなく汎用的な設定も追加しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- チョア
  - .gitignore を大幅に拡張し、OS/IDE設定、一時ファイル・ログ・バックアップ、環境変数例の保護、ビルド成果物や言語／フレームワーク（Node/PHP/WordPress等）のキャッシュや生成物、Homestead 関連などを網羅的に除外。誤コミット抑制と開発・CIの安定化を目的。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->