### PR TITLE
refactor: rename class from ProgramStorage to ProgramSaver

### DIFF
--- a/scraper.php
+++ b/scraper.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 require __DIR__ . '/vendor/autoload.php';
 
 use BOA\Programs\ProgramScraper;
-use BOA\Programs\ProgramStorage;
+use BOA\Programs\ProgramSaver;
 use BOA\Programs\ScraperAdapter;
 use BVP\Scraper\Scraper;
 use Carbon\CarbonImmutable as Carbon;
@@ -34,6 +34,6 @@ if (empty($programs ?? [])) {
 // 出走表データを JSON ファイルとして保存
 // 日付付きの JSON ファイルとして保存（例: docs/{version}/YYYY/YYYYMMDD.json）
 // 最新データとして today.json にも保存
-$storage = new ProgramStorage();
+$storage = new ProgramSaver();
 $storage->save($programs, "docs/{$version}/" . $date->format('Y') . '/' . $date->format('Ymd') . '.json');
 $storage->save($programs, "docs/{$version}/today.json");

--- a/scraper.php
+++ b/scraper.php
@@ -34,6 +34,6 @@ if (empty($programs ?? [])) {
 // 出走表データを JSON ファイルとして保存
 // 日付付きの JSON ファイルとして保存（例: docs/{version}/YYYY/YYYYMMDD.json）
 // 最新データとして today.json にも保存
-$storage = new ProgramSaver();
-$storage->save($programs, "docs/{$version}/" . $date->format('Y') . '/' . $date->format('Ymd') . '.json');
-$storage->save($programs, "docs/{$version}/today.json");
+$saver = new ProgramSaver();
+$saver->save($programs, "docs/{$version}/" . $date->format('Y') . '/' . $date->format('Ymd') . '.json');
+$saver->save($programs, "docs/{$version}/today.json");

--- a/src/ProgramSaver.php
+++ b/src/ProgramSaver.php
@@ -9,7 +9,7 @@ namespace BOA\Programs;
  *
  * @author shimomo
  */
-final class ProgramStorage
+final class ProgramSaver
 {
     /**
      * @psalm-param ScrapedStadiumRaces $programs

--- a/src/ProgramSaver.php
+++ b/src/ProgramSaver.php
@@ -29,7 +29,7 @@ final class ProgramSaver
         }
 
         $dir = dirname($path);
-        if (!is_dir($dir) && !mkdir($dir, 0777, true) && !is_dir($dir)) {
+        if (!is_dir($dir) && !mkdir($dir, 0755, true) && !is_dir($dir)) {
             throw new \RuntimeException("Failed to create directory: {$dir}");
         }
 

--- a/tests/ProgramSaverTest.php
+++ b/tests/ProgramSaverTest.php
@@ -28,7 +28,7 @@ final class ProgramSaverTest extends TestCase
     {
         parent::setUp();
         $this->tempDir = sys_get_temp_dir() . '/program_saver_test_' . uniqid();
-        mkdir($this->tempDir, 0777, true);
+        mkdir($this->tempDir, 0755, true);
     }
 
     /**

--- a/tests/ProgramSaverTest.php
+++ b/tests/ProgramSaverTest.php
@@ -27,8 +27,10 @@ final class ProgramSaverTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/program_saver_test_' . uniqid();
-        mkdir($this->tempDir, 0755, true);
+        $this->tempDir = sys_get_temp_dir() . '/program_saver_test_' . bin2hex(random_bytes(8));
+        if (!mkdir($this->tempDir, 0755, true) && !is_dir($this->tempDir)) {
+            $this->fail('Failed to create temp dir: ' . $this->tempDir);
+        }
     }
 
     /**

--- a/tests/ProgramSaverTest.php
+++ b/tests/ProgramSaverTest.php
@@ -59,7 +59,7 @@ final class ProgramSaverTest extends TestCase
      */
     public function testSave(): void
     {
-        $storage = new ProgramSaver();
+        $saver = new ProgramSaver();
         $path = $this->tempDir . '/programs.json';
 
         $programs = [
@@ -102,7 +102,7 @@ final class ProgramSaverTest extends TestCase
             ],
         ];
 
-        $storage->save($programs, $path);
+        $saver->save($programs, $path);
 
         $this->assertFileExists($path);
 

--- a/tests/ProgramSaverTest.php
+++ b/tests/ProgramSaverTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace BOA\Programs\Tests;
 
-use BOA\Programs\ProgramStorage;
+use BOA\Programs\ProgramSaver;
 use PHPUnit\Framework\TestCase;
 
 /**
  * @author shimomo
  */
-final class ProgramStorageTest extends TestCase
+final class ProgramSaverTest extends TestCase
 {
     /**
      * @psalm-var non-empty-string
@@ -59,7 +59,7 @@ final class ProgramStorageTest extends TestCase
      */
     public function testSave(): void
     {
-        $storage = new ProgramStorage();
+        $storage = new ProgramSaver();
         $path = $this->tempDir . '/programs.json';
 
         $programs = [

--- a/tests/ProgramSaverTest.php
+++ b/tests/ProgramSaverTest.php
@@ -27,7 +27,7 @@ final class ProgramSaverTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        $this->tempDir = sys_get_temp_dir() . '/program_storage_test_' . uniqid();
+        $this->tempDir = sys_get_temp_dir() . '/program_saver_test_' . uniqid();
         mkdir($this->tempDir, 0777, true);
     }
 


### PR DESCRIPTION
JSON ファイルを保存するだけなので直感的な Saver にリネームしました。また、ディレクトリ作成の権限を 0777 から 0755 に変更しました。さらに、一時ディレクトリの衝突耐性を強化しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - 内部コンポーネント名を ProgramStorage から ProgramSaver に統一し、保存処理周りの命名を整理しました。保存先のディレクトリ作成時のパーミッションを 0777→0755 に引き下げました。ユーザー向けの動作や出力に変更はありません。
- Tests
  - 自動テストを名称変更とパーミッション変更に合わせて更新し、同等の検証範囲と信頼性を維持しています。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->