### PR TITLE
ci: update push branches in psalm workflow

### DIFF
--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -22,13 +22,13 @@ jobs:
           - '8.4'
     steps:
       - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, xml
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
 
       - name: Install Dependencies
         run: composer install --prefer-dist --no-interaction --no-progress --dev

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           extensions: mbstring, xml
+          tools: composer:v2
+          coverage: none
 
       - name: Checkout Repository
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8

--- a/.github/workflows/psalm.yml
+++ b/.github/workflows/psalm.yml
@@ -3,7 +3,7 @@ name: psalm
 on:
   push:
     branches:
-      - '*.x'
+      - 'gh-pages'
   pull_request:
   schedule:
     - cron: '0 0 * * *'


### PR DESCRIPTION
Psalm 用のワークフローにおいてプッシュのブランチが存在しない *.x になっていたため、デフォルトブランチの gh-pages に変更しました。また、動作に影響しない範囲で微調整を行いました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - CIの静的解析ワークフローのpushトリガーをgh-pagesブランチに限定しました。
  - CIで利用するPHPセットアップとチェックアウト処理を特定のコミットに固定（バージョン固定）しました。
  - PHPセットアップにtools: composer:v2およびcoverage: noneの入力を追加しました。
  - pull_request、スケジュール、手動実行など他のトリガーは引き続き動作します。  
  - 機能やUIの変更はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->