### PR TITLE
chore: add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+      include: "scope"


### PR DESCRIPTION
GitHub Actions の SHA 固定を自動更新するために dependabot.yml を追加しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - GitHub Actions の依存関係を自動更新する設定を追加し、週次でチェックと更新を実行します。
  - リポジトリ全体を対象にし、コミットメッセージは「deps」プレフィックスとスコープを含む形式に統一します。
  - 手動対応の負担を軽減し、依存関係の最新化と保守性を向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->