### PR TITLE
ci: pin actions/checkout and shivammathur/setup-php action to specific commit

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -15,12 +15,12 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
         with:
           php-version: '8.4'
 
       - name: Checkout Code
-        uses: actions/checkout@v5
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Install base dependencies (without scraper)
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -22,12 +22,12 @@ jobs:
           - '8.4'
     steps:
       - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
         with:
           php-version: ${{ matrix.php-version }}
 
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Install Dependencies
         run: composer install --prefer-dist --no-interaction --no-progress --dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,13 +24,13 @@ jobs:
           - '12.0'
     steps:
       - name: Setup PHP ${{ matrix.php-version }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4
         with:
           php-version: ${{ matrix.php-version }}
           coverage: pcov
 
       - name: Checkout Repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493
 
       - name: Require PHPUnit ${{ matrix.phpunit-version }}
         run: composer require --dev phpunit/phpunit:^${{ matrix.phpunit-version }} --with-all-dependencies


### PR DESCRIPTION
セキュリティ強化のために actions/checkout と shivammathur/setup-php のバージョンを特定のコミット SHA に固定しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- チョア
  - CI ワークフローの外部アクションをコミットに固定し、ビルドの再現性と安定性を向上。定期実行・セキュリティ検査・テストの各パイプラインに適用。ユーザー向けの機能や挙動の変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->