### PR TITLE
ci: move permissions from job to workflow level

### DIFF
--- a/.github/workflows/keepalive.yml
+++ b/.github/workflows/keepalive.yml
@@ -9,12 +9,13 @@ concurrency:
   group: keepalive
   cancel-in-progress: false
 
+permissions:
+  actions: write
+
 jobs:
   keepalive:
     name: Keep Workflows Alive on Ubuntu 24.04
     runs-on: ubuntu-24.04
-    permissions:
-      actions: write
     steps:
       - name: Re-enable Workflows
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,13 +9,14 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   test:
     name: PHPUnit ${{ matrix.phpunit-version }} on PHP ${{ matrix.php-version }} (Ubuntu 24.04)
     runs-on: ubuntu-24.04
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       matrix:
         php-version:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:


### PR DESCRIPTION
ワークフロー全体にパーミッション設定を移動しました。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- チョア
  - CIワークフローの権限定義をワークフロー全体のトップレベルに移動し、一貫性と可読性を向上。
  - 各ジョブ内の重複する権限定義を削除して設定管理を簡素化。
  - アプリの機能や動作への影響はありません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->